### PR TITLE
Set default beat saver map sort order to Relevance

### DIFF
--- a/src/renderer/config/default-configuration.config.ts
+++ b/src/renderer/config/default-configuration.config.ts
@@ -30,7 +30,7 @@ export const defaultConfiguration: {
         window.electron.path.join("Beat Saber_Data", "CustomWIPLevels"),
     ],
     "playlist-sort-order": BsvSearchOrder.Relevance,
-    "map-sort-order": BsvSearchOrder.Latest,
+    "map-sort-order": BsvSearchOrder.Relevance,
 };
 
 export type ThemeConfig = "dark" | "light" | "os";


### PR DESCRIPTION
## Scope

Change default sort order of beatsaver maps to Relevance

Obviously you want to see Latest maps initially but fun fact: If you don't supply a search parameter Relevance returns the latest maps.

It's a really awful user experience to see the Latest maps when searching for something unless you've specifically asked for that:
(I know these aren't app screenshots but it's the same search results)
<img width="1327" alt="Screenshot 2024-11-18 at 16 28 49" src="https://github.com/user-attachments/assets/15292611-3793-44f3-aff7-438131e45ea1">
<img width="1313" alt="Screenshot 2024-11-18 at 16 28 59" src="https://github.com/user-attachments/assets/f35031d1-bcd3-4130-832d-86fb746546d7">
